### PR TITLE
feat: コース、カリキュラムを消すと、依存する中間テーブルのデータを消す

### DIFF
--- a/frontend/prisma/migrations/20230419020121_ondelete/migration.sql
+++ b/frontend/prisma/migrations/20230419020121_ondelete/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE `CourseCurriculumRelation` DROP FOREIGN KEY `CourseCurriculumRelation_courseId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `CourseCurriculumRelation` DROP FOREIGN KEY `CourseCurriculumRelation_curriculumId_fkey`;
+
+-- AddForeignKey
+ALTER TABLE `CourseCurriculumRelation` ADD CONSTRAINT `CourseCurriculumRelation_courseId_fkey` FOREIGN KEY (`courseId`) REFERENCES `Course`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `CourseCurriculumRelation` ADD CONSTRAINT `CourseCurriculumRelation_curriculumId_fkey` FOREIGN KEY (`curriculumId`) REFERENCES `Curriculum`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -29,9 +29,9 @@ model Curriculum {
 
 // 順番の番号も必要
 model CourseCurriculumRelation {
-  course       Course     @relation(fields: [courseId], references: [id])
+  course       Course     @relation(fields: [courseId], references: [id], onDelete: Cascade)
   courseId     String
-  curriculum   Curriculum @relation(fields: [curriculumId], references: [id])
+  curriculum   Curriculum @relation(fields: [curriculumId], references: [id], onDelete: Cascade)
   curriculumId String
 
   @@id([courseId, curriculumId])

--- a/frontend/src/components/CourseItem.tsx
+++ b/frontend/src/components/CourseItem.tsx
@@ -64,7 +64,7 @@ export const CourseItem: FC<{ id: string }> = ({ id }) => {
     } catch (e) {
       console.error(e)
     }
-  }, [selectedCurriculumId])
+  }, [curriculumIds, id, selectedCurriculumId])
 
   const removeCurriculum = useCallback(async () => {
     if (!selectedCurriculumId) {
@@ -93,18 +93,15 @@ export const CourseItem: FC<{ id: string }> = ({ id }) => {
     } catch (e) {
       console.error(e)
     }
-  }, [selectedCurriculumId])
+  }, [curriculumIds, id, selectedCurriculumId])
 
   return (
     <div style={{ margin: '0 20px' }}>
       <h2>
         {course?.name} id: {id}
       </h2>
-
-      {JSON.stringify(course)}
       <p>curriculumIds</p>
       <p>{JSON.stringify(curriculumIds)}</p>
-      <p>{JSON.stringify(course?.curriculums)}</p>
 
       {/* select */}
       {curriculums && (
@@ -124,13 +121,10 @@ export const CourseItem: FC<{ id: string }> = ({ id }) => {
       )}
       {selectedCurriculumId}
 
-      <h3>コースのカリキュラム一覧</h3>
+      <h3>「{course?.name}」のカリキュラム一覧</h3>
       <ul>
         {orderdCurriculums?.map(curriculum => (
-          <li key={curriculum.id}>
-            <p> {curriculum.id}</p>
-            <p>{curriculum.name}</p>
-          </li>
+          <li key={curriculum.id}>{curriculum.name}</li>
         ))}
       </ul>
     </div>

--- a/frontend/src/components/CourseList.tsx
+++ b/frontend/src/components/CourseList.tsx
@@ -42,10 +42,14 @@ export const CourseList: FC = () => {
   return (
     <div>
       <h2>Course</h2>
-      <p>course 1</p>
-      <p>{JSON.stringify(courses?.[0])}</p>
-      <p>course 全部</p>
-      <p>{JSON.stringify(courses)}</p>
+
+      <ul>
+        {courses?.map(course => (
+          <li key={course.id} value={course.id}>
+            {course.name}
+          </li>
+        ))}
+      </ul>
 
       <p>
         <input

--- a/frontend/src/components/CurriculumItem.tsx
+++ b/frontend/src/components/CurriculumItem.tsx
@@ -43,7 +43,13 @@ export const CurriculumItem: FC = () => {
   return (
     <div>
       <h2>Curriculum</h2>
-      {JSON.stringify(curriculums)}
+      <ul>
+        {curriculums?.map(curriculum => (
+          <li key={curriculum.id} value={curriculum.id}>
+            {curriculum.name}
+          </li>
+        ))}
+      </ul>
 
       <p>
         <label>

--- a/frontend/src/components/Relation.tsx
+++ b/frontend/src/components/Relation.tsx
@@ -1,18 +1,24 @@
 import { FC, useCallback, useEffect, useState } from 'react'
-import { Course, CourseCurriculumRelation } from '@prisma/client'
 import { useGetApi } from '../hooks/useApi'
 
+type CourseCurriculumRelation = {
+  courseId: string
+  curriculumId: string
+  courseName: string
+  curriculumName: string
+}
+
 export const Relation: FC = () => {
-  const { data: courses } =
+  const { data: relations } =
     useGetApi<CourseCurriculumRelation[]>(`/samples/all`)
 
   return (
     <div>
       <h2>Relation</h2>
       <ul>
-        {courses?.map(c => (
+        {relations?.map(c => (
           <li key={`${c.courseId} ${c.curriculumId}`}>
-            {c.courseId}, {c.curriculumId}
+            {c.courseName}, {c.curriculumName}
           </li>
         ))}
       </ul>

--- a/frontend/src/pages/api/samples/all.ts
+++ b/frontend/src/pages/api/samples/all.ts
@@ -6,8 +6,20 @@ export default async function handler(
   res: NextApiResponse,
 ) {
   try {
-    const course = await prisma.courseCurriculumRelation.findMany({})
-    res.status(200).json({ data: course })
+    const relations = await prisma.courseCurriculumRelation.findMany({
+      include: {
+        course: true,
+        curriculum: true,
+      },
+    })
+    const resulut = relations.map(relation => ({
+      courseId: relation.courseId,
+      curriculumId: relation.curriculumId,
+      courseName: relation.course.name,
+      curriculumName: relation.curriculum.name,
+    }))
+
+    res.status(200).json({ data: resulut })
   } catch (err) {
     res.status(400).json({ data: err })
   }

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -13,6 +13,9 @@ import { useGetApi } from '../hooks/useApi'
 
 const Home: NextPage = () => {
   const { data: courses } = useGetApi<Course[]>(`/courses`)
+  const [selectedCourseId, setselectedCourseId] = useState(
+    courses?.[0]?.id || '',
+  )
 
   return (
     <div className={styles.container}>
@@ -26,7 +29,22 @@ const Home: NextPage = () => {
         <div style={{ wordBreak: 'break-all' }}>
           <Link href='/page2'>page2</Link>
           <CourseList />
-          {courses?.[0]?.id && <CourseItem id={courses[0].id} />}
+          <br />
+          <h2>コース選択</h2>
+          {courses && (
+            <>
+              <select onChange={e => setselectedCourseId(e.target.value)}>
+                {courses.map(curriculum => (
+                  <option key={curriculum.id} value={curriculum.id}>
+                    {curriculum.name}
+                  </option>
+                ))}
+              </select>
+            </>
+          )}
+          {selectedCourseId}
+          {/* {courses?.[0]?.id && <CourseItem id={courses[0].id} />} */}
+          {selectedCourseId && <CourseItem id={selectedCourseId} />}
 
           <CurriculumItem />
 


### PR DESCRIPTION
## 詳細
- コース・カリキュラムを消したとき、依存している中間テーブルのデータを全て消す。

## 動作確認

「消すコース」というコースを作成
![スクリーンショット 2023-04-19 112413](https://user-images.githubusercontent.com/88410576/232951698-1bd6201d-bd25-4e1a-ba74-8b027a846cb1.png)

いくつかのカリキュラムと紐づける
![スクリーンショット 2023-04-19 112645](https://user-images.githubusercontent.com/88410576/232951686-69689fab-aaba-4966-bfa5-c6f12ebc7abd.png)

![スクリーンショット 2023-04-19 112711](https://user-images.githubusercontent.com/88410576/232951656-110c1078-e169-4745-8319-6864a150c8ae.png)


「消すコース」を削除
![スクリーンショット 2023-04-19 112734](https://user-images.githubusercontent.com/88410576/232951644-efaa8487-cde5-4214-a7f5-f7458cc48496.png)


カリキュラムは変わらない
![スクリーンショット 2023-04-19 112757](https://user-images.githubusercontent.com/88410576/232951633-cdcf6c15-0ba3-48db-98b1-e4bb746893c2.png)

リレーションから「消すコース」のデータが消える
![スクリーンショット 2023-04-19 112803](https://user-images.githubusercontent.com/88410576/232951625-59a76b1c-096a-4ccf-988e-2560da2b6868.png)
