### PR TITLE
api/v1でGETのみのエンドポイントを作成

### DIFF
--- a/frontend/src/pages/api/v1/courses/[id].ts
+++ b/frontend/src/pages/api/v1/courses/[id].ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import prisma from '@/libs/prisma'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const id = String(req.query.id)
+
+  // api/v1/courses/[id]
+  try {
+    const course = await prisma.course.findUnique({
+      where: {
+        id: id,
+      },
+      include: {
+        curriculums: {
+          include: {
+            curriculum: true,
+          },
+          orderBy: { createdAt: 'asc' },
+        },
+      },
+    })
+
+    // courseがnullならnullを返す
+    const courseWithCurriculums = course && {
+      ...course,
+      curriculums: course?.curriculums.map(ccr => ccr.curriculum),
+    }
+    res.status(200).json({ data: courseWithCurriculums })
+  } catch (err) {
+    res.status(400).json({ data: err })
+  }
+}

--- a/frontend/src/pages/api/v1/courses/index.ts
+++ b/frontend/src/pages/api/v1/courses/index.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import prisma from '@/libs/prisma'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  // api/v1/courses
+  try {
+    const courses = await prisma.course.findMany({
+      include: {
+        curriculums: {
+          include: { curriculum: true },
+          orderBy: { createdAt: 'asc' },
+        },
+      },
+      orderBy: { createdAt: 'asc' },
+    })
+
+    // {id, name, description, level, curriculumIds, curriculums: [{}]}
+    const coursesWithCurriculums = courses.map(course => ({
+      ...course,
+      curriculums: course.curriculums.map(c => c.curriculum),
+    }))
+    res.status(200).json({ data: coursesWithCurriculums })
+  } catch (err) {
+    res.status(400).json({ data: err })
+  }
+}

--- a/frontend/src/pages/api/v1/curriculums/[id].ts
+++ b/frontend/src/pages/api/v1/curriculums/[id].ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import prisma from '@/libs/prisma'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const id = String(req.query.id)
+
+  // curriculums/[id]
+  try {
+    const curriculum = await prisma.curriculum.findUnique({
+      where: {
+        id: id,
+      },
+    })
+    res.status(200).json({ data: curriculum })
+  } catch (err) {
+    res.status(400).json({ data: err })
+  }
+}

--- a/frontend/src/pages/api/v1/curriculums/index.ts
+++ b/frontend/src/pages/api/v1/curriculums/index.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import prisma from '@/libs/prisma'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  try {
+    const curriculums = await prisma.curriculum.findMany({
+      orderBy: { createdAt: 'asc' },
+    })
+    res.status(200).json({ data: curriculums })
+  } catch (err) {
+    res.status(400).json({ data: err })
+  }
+}


### PR DESCRIPTION
## 詳細
メインのシステムで使う用のAPI のエンドポイント作成。GETメソッドのみ
- api/v1/courses
- api/v1/courses/[id]
- api/v1/curriculums
- api/v1/curriculums/[id]


## 動作確認
![image](https://user-images.githubusercontent.com/88410576/236678094-fee4060b-b3c6-4a37-9ba9-471b0cc87357.png)
