### PR TITLE
モーダルフォームで内容破棄の確認アラートの実装

### DIFF
--- a/frontend/src/features/course/components/CourseForm.tsx
+++ b/frontend/src/features/course/components/CourseForm.tsx
@@ -8,7 +8,7 @@ import {
   TextInput,
   Textarea,
 } from '@mantine/core'
-import { FC } from 'react'
+import { FC, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { AlertCircle } from 'tabler-icons-react'
 import { z } from 'zod'
@@ -22,18 +22,20 @@ type Props = {
   onSubmit: (params: CourseFormRequest) => void
   submitButtonName?: string
   initValue?: CourseFormRequest
+  onDirty: () => void
 }
 
 export const CourseForm: FC<Props> = ({
   onSubmit: onSubmitProps,
   submitButtonName,
   initValue,
+  onDirty,
 }) => {
   const {
     register,
     handleSubmit,
     setValue,
-    formState: { errors },
+    formState: { errors, isDirty },
   } = useForm<CourseFormRequest>({
     resolver: zodResolver(courseSchema),
     criteriaMode: 'all',
@@ -42,6 +44,11 @@ export const CourseForm: FC<Props> = ({
 
   const { onSubmit, errorMessage, clearErrorMessage } =
     useFormErrorHandling<CourseFormRequest>(onSubmitProps)
+
+  // useEffectを使わないと、レンダリング中にsetStateを呼ぶことになりWarningが出る
+  useEffect(() => {
+    if (isDirty) onDirty()
+  }, [isDirty, onDirty])
 
   return (
     <>

--- a/frontend/src/features/course/components/CreateCourseButton.tsx
+++ b/frontend/src/features/course/components/CreateCourseButton.tsx
@@ -1,5 +1,5 @@
 import { Button, Modal } from '@mantine/core'
-import { FC } from 'react'
+import { FC, useCallback } from 'react'
 
 import { useBoolean } from '@/hooks/useBoolean'
 
@@ -11,22 +11,38 @@ type Props = {
 
 export const CreateCourseButton: FC<Props> = ({ onSubmit }) => {
   const isOpen = useBoolean()
+  const isDirtyForm = useBoolean()
+
+  const onClose = useCallback(() => {
+    if (!isDirtyForm.v) {
+      isOpen.setFalse()
+      isDirtyForm.setFalse()
+      return
+    }
+
+    if (window.confirm('編集内容を破棄しますか？')) {
+      isOpen.setFalse()
+      isDirtyForm.setFalse()
+    }
+  }, [isDirtyForm, isOpen])
 
   return (
     <>
       <Button onClick={isOpen.setTrue}>新規コース作成</Button>
       <Modal
         opened={isOpen.v}
-        onClose={isOpen.setFalse}
+        onClose={onClose}
         title='新規コース作成'
         centered
         classNames={{ title: 'text-xl' }}
       >
         <CourseForm
+          key={String(isOpen.v)}
           onSubmit={async v => {
             await onSubmit(v)
             isOpen.setFalse()
           }}
+          onDirty={isDirtyForm.setTrue}
           submitButtonName='作成する'
         />
       </Modal>

--- a/frontend/src/features/course/components/CreateCourseButton.tsx
+++ b/frontend/src/features/course/components/CreateCourseButton.tsx
@@ -1,7 +1,7 @@
 import { Button, Modal } from '@mantine/core'
-import { FC, useCallback } from 'react'
+import { FC } from 'react'
 
-import { useBoolean } from '@/hooks/useBoolean'
+import { useModalForm } from '@/hooks/useModalForm'
 
 import { CourseForm, CourseFormRequest } from './CourseForm'
 
@@ -9,22 +9,8 @@ type Props = {
   onSubmit: (params: CourseFormRequest) => void
 }
 
-export const CreateCourseButton: FC<Props> = ({ onSubmit }) => {
-  const isOpen = useBoolean()
-  const isDirtyForm = useBoolean()
-
-  const onClose = useCallback(() => {
-    if (!isDirtyForm.v) {
-      isOpen.setFalse()
-      isDirtyForm.setFalse()
-      return
-    }
-
-    if (window.confirm('編集内容を破棄しますか？')) {
-      isOpen.setFalse()
-      isDirtyForm.setFalse()
-    }
-  }, [isDirtyForm, isOpen])
+export const CreateCourseButton: FC<Props> = ({ onSubmit: onSubmitProps }) => {
+  const { isOpen, isDirtyForm, onClose, onSubmit } = useModalForm(onSubmitProps)
 
   return (
     <>
@@ -38,10 +24,7 @@ export const CreateCourseButton: FC<Props> = ({ onSubmit }) => {
       >
         <CourseForm
           key={String(isOpen.v)}
-          onSubmit={async v => {
-            await onSubmit(v)
-            isOpen.setFalse()
-          }}
+          onSubmit={onSubmit}
           onDirty={isDirtyForm.setTrue}
           submitButtonName='作成する'
         />

--- a/frontend/src/features/course/components/UpdateCourseButton.tsx
+++ b/frontend/src/features/course/components/UpdateCourseButton.tsx
@@ -1,7 +1,7 @@
 import { Button, Modal } from '@mantine/core'
 import { FC } from 'react'
 
-import { useBoolean } from '@/hooks/useBoolean'
+import { useModalForm } from '@/hooks/useModalForm'
 
 import { CourseForm, CourseFormRequest } from './CourseForm'
 
@@ -10,24 +10,26 @@ type Props = {
   initValue: CourseFormRequest
 }
 
-export const UpdateCourseButton: FC<Props> = ({ onSubmit, initValue }) => {
-  const isOpen = useBoolean()
+export const UpdateCourseButton: FC<Props> = ({
+  onSubmit: onSubmitProps,
+  initValue,
+}) => {
+  const { isOpen, isDirtyForm, onClose, onSubmit } = useModalForm(onSubmitProps)
 
   return (
     <>
       <Button onClick={isOpen.setTrue}>編集</Button>
       <Modal
         opened={isOpen.v}
-        onClose={isOpen.setFalse}
+        onClose={onClose}
         title='コース編集'
         centered
         classNames={{ title: 'text-xl' }}
       >
         <CourseForm
-          onSubmit={async v => {
-            await onSubmit(v)
-            isOpen.setFalse()
-          }}
+          key={String(isOpen.v)}
+          onSubmit={onSubmit}
+          onDirty={isDirtyForm.setTrue}
           submitButtonName='更新する'
           initValue={initValue}
         />

--- a/frontend/src/features/curriculum/components/CreateCurriculumButton.tsx
+++ b/frontend/src/features/curriculum/components/CreateCurriculumButton.tsx
@@ -1,7 +1,7 @@
 import { Button, Modal } from '@mantine/core'
 import { FC } from 'react'
 
-import { useBoolean } from '@/hooks/useBoolean'
+import { useModalForm } from '@/hooks/useModalForm'
 
 import { CurriculumForm, CurriculumFormRequest } from './CurriculumForm'
 
@@ -9,24 +9,25 @@ type Props = {
   onSubmit: (params: CurriculumFormRequest) => void
 }
 
-export const CreateCurriculumButton: FC<Props> = ({ onSubmit }) => {
-  const isOpen = useBoolean()
+export const CreateCurriculumButton: FC<Props> = ({
+  onSubmit: onSubmitProps,
+}) => {
+  const { isOpen, isDirtyForm, onClose, onSubmit } = useModalForm(onSubmitProps)
 
   return (
     <>
       <Button onClick={isOpen.setTrue}>新規カリキュラム作成</Button>
       <Modal
         opened={isOpen.v}
-        onClose={isOpen.setFalse}
+        onClose={onClose}
         title='新規カリキュラム作成'
         centered
         classNames={{ title: 'text-xl' }}
       >
         <CurriculumForm
-          onSubmit={async v => {
-            await onSubmit(v)
-            isOpen.setFalse()
-          }}
+          key={String(isOpen.v)}
+          onSubmit={onSubmit}
+          onDirty={isDirtyForm.setTrue}
           submitButtonName='作成する'
         />
       </Modal>

--- a/frontend/src/features/curriculum/components/CurriculumForm.tsx
+++ b/frontend/src/features/curriculum/components/CurriculumForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Alert, Button, Flex, Stack, TextInput, Textarea } from '@mantine/core'
-import { FC } from 'react'
+import { FC, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { AlertCircle } from 'tabler-icons-react'
 import { z } from 'zod'
@@ -14,17 +14,19 @@ type Props = {
   onSubmit: (params: CurriculumFormRequest) => void
   submitButtonName?: string
   initValue?: CurriculumFormRequest
+  onDirty: () => void
 }
 
 export const CurriculumForm: FC<Props> = ({
   onSubmit: onSubmitProps,
   submitButtonName,
   initValue,
+  onDirty,
 }) => {
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isDirty },
   } = useForm<CurriculumFormRequest>({
     resolver: zodResolver(curriculumSchema),
     criteriaMode: 'all',
@@ -33,6 +35,11 @@ export const CurriculumForm: FC<Props> = ({
 
   const { onSubmit, errorMessage, clearErrorMessage } =
     useFormErrorHandling<CurriculumFormRequest>(onSubmitProps)
+
+  // useEffectを使わないと、レンダリング中にsetStateを呼ぶことになりWarningが出る
+  useEffect(() => {
+    if (isDirty) onDirty()
+  }, [isDirty, onDirty])
 
   return (
     <>

--- a/frontend/src/features/curriculum/components/UpdateCurriculumButton.tsx
+++ b/frontend/src/features/curriculum/components/UpdateCurriculumButton.tsx
@@ -1,7 +1,7 @@
 import { Button, Modal } from '@mantine/core'
 import { FC } from 'react'
 
-import { useBoolean } from '@/hooks/useBoolean'
+import { useModalForm } from '@/hooks/useModalForm'
 
 import { CurriculumForm, CurriculumFormRequest } from './CurriculumForm'
 
@@ -10,24 +10,26 @@ type Props = {
   initValue: CurriculumFormRequest
 }
 
-export const UpdateCurriculumButton: FC<Props> = ({ onSubmit, initValue }) => {
-  const isOpen = useBoolean()
+export const UpdateCurriculumButton: FC<Props> = ({
+  onSubmit: onSubmitProps,
+  initValue,
+}) => {
+  const { isOpen, isDirtyForm, onClose, onSubmit } = useModalForm(onSubmitProps)
 
   return (
     <>
       <Button onClick={isOpen.setTrue}>編集</Button>
       <Modal
         opened={isOpen.v}
-        onClose={isOpen.setFalse}
+        onClose={onClose}
         title='カリキュラム編集'
         centered
         classNames={{ title: 'text-xl' }}
       >
         <CurriculumForm
-          onSubmit={async v => {
-            await onSubmit(v)
-            isOpen.setFalse()
-          }}
+          key={String(isOpen.v)}
+          onSubmit={onSubmit}
+          onDirty={isDirtyForm.setTrue}
           submitButtonName='更新する'
           initValue={initValue}
         />

--- a/frontend/src/hooks/useModalForm.ts
+++ b/frontend/src/hooks/useModalForm.ts
@@ -1,0 +1,31 @@
+import { useCallback } from 'react'
+
+import { useBoolean } from './useBoolean'
+
+export const useModalForm = <T>(onSubmitProps: (params: T) => void) => {
+  const isOpen = useBoolean()
+  const isDirtyForm = useBoolean()
+
+  const onClose = useCallback(() => {
+    if (!isDirtyForm.v) {
+      isOpen.setFalse()
+      isDirtyForm.setFalse()
+      return
+    }
+
+    if (window.confirm('編集内容を破棄しますか？')) {
+      isOpen.setFalse()
+      isDirtyForm.setFalse()
+    }
+  }, [isDirtyForm, isOpen])
+
+  const onSubmit = useCallback(
+    async (params: T) => {
+      await onSubmitProps(params)
+      isOpen.setFalse()
+    },
+    [isOpen, onSubmitProps],
+  )
+
+  return { isOpen, isDirtyForm, onClose, onSubmit }
+}


### PR DESCRIPTION
## 詳細
- 以下のモーダルフォームに、内容破棄の確認アラートを実装
  - コース作成・編集モーダル
  - カリキュラム作成・編集モーダル
- モーダルコンポーネントのロジックをカスタムフックに切り出す

## 実装内容
1. モーダルでフォームが一度でも入力されたかを保持(isDirty)
2. フォームで入力されたら、isDirtyをtrueにする
3. isDirtyがtrueの時、モーダルを閉じようとする時にアラートを出す
4. アラートをキャンセルすると元の画面に戻り、OKすると内容が破棄されてモーダルが閉じる

## 動作確認

![q](https://github.com/shin-lab-sec/cyber-range-cms/assets/88410576/c255639f-4873-4b22-a525-a236dde6ec46)
