### PR TITLE
モーダルフォームの入力破棄の確認アラートの修正

### DIFF
--- a/frontend/src/features/userAgent/components/CreateUserAgentButton.tsx
+++ b/frontend/src/features/userAgent/components/CreateUserAgentButton.tsx
@@ -1,7 +1,7 @@
 import { Button, Modal } from '@mantine/core'
 import { FC } from 'react'
 
-import { useBoolean } from '@/hooks/useBoolean'
+import { useModalForm } from '@/hooks/useModalForm'
 
 import { UserAgentFormRequest, UserAgentForm } from './UserAgentForm'
 
@@ -9,24 +9,25 @@ type Props = {
   onSubmit: (params: UserAgentFormRequest) => void
 }
 
-export const CreateUserAgentButton: FC<Props> = ({ onSubmit }) => {
-  const isOpen = useBoolean()
+export const CreateUserAgentButton: FC<Props> = ({
+  onSubmit: onSubmitProps,
+}) => {
+  const { isOpen, isDirtyForm, onClose, onSubmit } = useModalForm(onSubmitProps)
 
   return (
     <>
       <Button onClick={isOpen.setTrue}>新規ユーザーエージェント作成</Button>
       <Modal
         opened={isOpen.v}
-        onClose={isOpen.setFalse}
+        onClose={onClose}
         title='新規ユーザーエージェント作成'
         centered
         classNames={{ title: 'text-xl' }}
       >
         <UserAgentForm
-          onSubmit={async v => {
-            await onSubmit(v)
-            isOpen.setFalse()
-          }}
+          key={String(isOpen.v)}
+          onSubmit={onSubmit}
+          onDirty={isDirtyForm.setTrue}
           submitButtonName='作成する'
         />
       </Modal>

--- a/frontend/src/features/userAgent/components/UpdateUserAgentButton.tsx
+++ b/frontend/src/features/userAgent/components/UpdateUserAgentButton.tsx
@@ -1,7 +1,7 @@
 import { Button, Modal } from '@mantine/core'
 import { FC } from 'react'
 
-import { useBoolean } from '@/hooks/useBoolean'
+import { useModalForm } from '@/hooks/useModalForm'
 
 import { UserAgentForm, UserAgentFormRequest } from './UserAgentForm'
 
@@ -10,24 +10,26 @@ type Props = {
   initValue: UserAgentFormRequest
 }
 
-export const UpdateUserAgentButton: FC<Props> = ({ onSubmit, initValue }) => {
-  const isOpen = useBoolean()
+export const UpdateUserAgentButton: FC<Props> = ({
+  onSubmit: onSubmitProps,
+  initValue,
+}) => {
+  const { isOpen, isDirtyForm, onClose, onSubmit } = useModalForm(onSubmitProps)
 
   return (
     <>
       <Button onClick={isOpen.setTrue}>編集</Button>
       <Modal
         opened={isOpen.v}
-        onClose={isOpen.setFalse}
+        onClose={onClose}
         title='ユーザーエージェント編集'
         centered
         classNames={{ title: 'text-xl' }}
       >
         <UserAgentForm
-          onSubmit={async v => {
-            await onSubmit(v)
-            isOpen.setFalse()
-          }}
+          key={String(isOpen.v)}
+          onSubmit={onSubmit}
+          onDirty={isDirtyForm.setTrue}
           submitButtonName='更新する'
           initValue={initValue}
         />

--- a/frontend/src/features/userAgent/components/UserAgentForm.tsx
+++ b/frontend/src/features/userAgent/components/UserAgentForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Alert, Button, Flex, Stack, TextInput } from '@mantine/core'
-import { FC } from 'react'
+import { FC, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { AlertCircle } from 'tabler-icons-react'
 import { z } from 'zod'
@@ -14,17 +14,19 @@ type Props = {
   onSubmit: (params: UserAgentFormRequest) => void
   submitButtonName?: string
   initValue?: UserAgentFormRequest
+  onDirty: () => void
 }
 
 export const UserAgentForm: FC<Props> = ({
   onSubmit: onSubmitProps,
   submitButtonName,
   initValue,
+  onDirty,
 }) => {
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isDirty },
   } = useForm<UserAgentFormRequest>({
     resolver: zodResolver(userAgentSchema),
     criteriaMode: 'all',
@@ -33,6 +35,11 @@ export const UserAgentForm: FC<Props> = ({
 
   const { onSubmit, errorMessage, clearErrorMessage } =
     useFormErrorHandling<UserAgentFormRequest>(onSubmitProps)
+
+  // useEffectを使わないと、レンダリング中にsetStateを呼ぶことになりWarningが出る
+  useEffect(() => {
+    if (isDirty) onDirty()
+  }, [isDirty, onDirty])
 
   return (
     <>

--- a/frontend/src/hooks/useModalForm.ts
+++ b/frontend/src/hooks/useModalForm.ts
@@ -23,8 +23,9 @@ export const useModalForm = <T>(onSubmitProps: (params: T) => void) => {
     async (params: T) => {
       await onSubmitProps(params)
       isOpen.setFalse()
+      isDirtyForm.setFalse()
     },
-    [isOpen, onSubmitProps],
+    [isDirtyForm, isOpen, onSubmitProps],
   )
 
   return { isOpen, isDirtyForm, onClose, onSubmit }


### PR DESCRIPTION
## 詳細
- userAgentのモーダルでも実装する
- フォームを送信した後、同じフォームを開くとDirtyがtrueになっているのを修正

## 動作確認
修正前

![zz](https://github.com/shin-lab-sec/cyber-range-cms/assets/88410576/d4f4ea61-68b7-4482-b273-b973d304340f)

修正後

![zzz](https://github.com/shin-lab-sec/cyber-range-cms/assets/88410576/96d9c6ad-a5fc-4fdf-ac3c-0dc8ec01ce72)

