### PR TITLE
各ページのタイトル、スタイル、カリキュラム・ユーザーエージェントの文言を修正

### DIFF
--- a/frontend/src/features/curriculum/components/CreateCurriculumButton.tsx
+++ b/frontend/src/features/curriculum/components/CreateCurriculumButton.tsx
@@ -16,11 +16,11 @@ export const CreateCurriculumButton: FC<Props> = ({
 
   return (
     <>
-      <Button onClick={isOpen.setTrue}>新規カリキュラム作成</Button>
+      <Button onClick={isOpen.setTrue}>カリキュラム登録</Button>
       <Modal
         opened={isOpen.v}
         onClose={onClose}
-        title='新規カリキュラム作成'
+        title='カリキュラム登録'
         centered
         classNames={{ title: 'text-xl' }}
       >
@@ -28,7 +28,7 @@ export const CreateCurriculumButton: FC<Props> = ({
           key={String(isOpen.v)}
           onSubmit={onSubmit}
           onDirty={isDirtyForm.setTrue}
-          submitButtonName='作成する'
+          submitButtonName='登録する'
         />
       </Modal>
     </>

--- a/frontend/src/features/userAgent/components/CreateUserAgentButton.tsx
+++ b/frontend/src/features/userAgent/components/CreateUserAgentButton.tsx
@@ -16,11 +16,11 @@ export const CreateUserAgentButton: FC<Props> = ({
 
   return (
     <>
-      <Button onClick={isOpen.setTrue}>新規ユーザーエージェント作成</Button>
+      <Button onClick={isOpen.setTrue}>ユーザーエージェント登録</Button>
       <Modal
         opened={isOpen.v}
         onClose={onClose}
-        title='新規ユーザーエージェント作成'
+        title='ユーザーエージェント登録'
         centered
         classNames={{ title: 'text-xl' }}
       >
@@ -28,7 +28,7 @@ export const CreateUserAgentButton: FC<Props> = ({
           key={String(isOpen.v)}
           onSubmit={onSubmit}
           onDirty={isDirtyForm.setTrue}
-          submitButtonName='作成する'
+          submitButtonName='登録する'
         />
       </Modal>
     </>

--- a/frontend/src/pages/courses/[id].tsx
+++ b/frontend/src/pages/courses/[id].tsx
@@ -73,7 +73,7 @@ const Courses: NextPage = () => {
   if (!course || !id) {
     return (
       <Layout>
-        <div>このコースは存在しません</div>
+        <p className='mt-200px text-center '>このコースは存在しません</p>
       </Layout>
     )
   }

--- a/frontend/src/pages/courses/index.tsx
+++ b/frontend/src/pages/courses/index.tsx
@@ -115,14 +115,13 @@ const Courses: NextPage = () => {
 
   return (
     <Layout>
-      <h1>コース一覧ページ</h1>
-
-      <Flex gap='sm' justify='end'>
+      <Flex gap='sm' justify='space-between' align='center'>
+        <h1>コース一覧</h1>
         <CreateCourseButton onSubmit={createCourse} />
       </Flex>
 
       {courses?.length ? (
-        <div className='mt-3'>
+        <div className='mt-8'>
           <MantineReactTable
             columns={columns}
             data={courses}

--- a/frontend/src/pages/curriculums.tsx
+++ b/frontend/src/pages/curriculums.tsx
@@ -141,14 +141,13 @@ const Curriculums: NextPage = () => {
 
   return (
     <Layout>
-      <h1>カリキュラム一覧ページ</h1>
-
-      <Flex gap='sm' justify='end'>
+      <Flex gap='sm' justify='space-between' align='center'>
+        <h1>カリキュラム一覧</h1>
         <CreateCurriculumButton onSubmit={createCurriculum} />
       </Flex>
 
       {curriculums?.length ? (
-        <div className='mt-3'>
+        <div className='mt-8'>
           <MantineReactTable
             columns={columns}
             data={curriculums}

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -5,7 +5,7 @@ import { Layout } from '@/components/Layout'
 const Login: NextPage = () => {
   return (
     <Layout>
-      <h1>ログインページ</h1>
+      <h1>ログイン</h1>
     </Layout>
   )
 }

--- a/frontend/src/pages/useragents.tsx
+++ b/frontend/src/pages/useragents.tsx
@@ -91,14 +91,13 @@ const UserAgents: NextPage = () => {
 
   return (
     <Layout>
-      <h1>ユーザーエージェント一覧ページ</h1>
-
-      <Flex gap='sm' justify='end'>
+      <Flex gap='sm' justify='space-between' align='center'>
+        <h1>ユーザーエージェント一覧</h1>
         <CreateUserAgentButton onSubmit={createUserAgent} />
       </Flex>
 
       {userAgents?.length ? (
-        <div className='mt-3'>
+        <div className='mt-8'>
           <MantineReactTable
             columns={columns}
             data={userAgents}


### PR DESCRIPTION
## 詳細
- カリキュラム・ユーザーエージェントのフォームの文言を、作成から登録へ修正
- 各ページ
  - タイトルの文言を、「○○ページ」の「ページ」を消す
    - コース一覧ページ -> コース一覧
  - スタイルを整える
    - タイトルと作成ボタンの高さを揃える
    - タイトルの下のマージンを揃える



## 動作確認

![image](https://github.com/shin-lab-sec/cyber-range-cms/assets/88410576/a3bf6de2-9bf3-4fd7-beb8-c7f05cb44c6f)

![image](https://github.com/shin-lab-sec/cyber-range-cms/assets/88410576/563b7aae-b5b1-47dc-a5c2-de95ea68d6ea)

![image](https://github.com/shin-lab-sec/cyber-range-cms/assets/88410576/824988a0-0044-48d1-a364-a6a30f9bed8e)


カリキュラム・ユーザーエージェントの登録フォーム
![image](https://github.com/shin-lab-sec/cyber-range-cms/assets/88410576/6ae5472f-f0ef-49ec-9a8c-afa1b6f8bd52)

![image](https://github.com/shin-lab-sec/cyber-range-cms/assets/88410576/4906e870-df53-44a6-9f52-bc96aee3235c)



