### PR TITLE
feat: 日付を日本時間で表示

### DIFF
--- a/frontend/src/pages/courses/index.tsx
+++ b/frontend/src/pages/courses/index.tsx
@@ -17,6 +17,7 @@ import {
   UpdateCourseButton,
 } from '@/features/course'
 import { useGetApi } from '@/hooks/useApi'
+import { convertToJapanTime } from '@/utils/convertToJapanTime'
 
 const Courses: NextPage = () => {
   const { data: courses } = useGetApi<CourseWithCurriculums[]>(`/courses`)
@@ -71,13 +72,13 @@ const Courses: NextPage = () => {
         accessorKey: 'createdAt',
         header: '作成日',
         maxSize: 0,
-        Cell: ({ cell }) => String(cell.getValue()).slice(0, 10),
+        Cell: ({ cell }) => convertToJapanTime(cell.getValue() as string),
       },
       {
         accessorKey: 'updatedAt',
         header: '最終更新日',
         maxSize: 0,
-        Cell: ({ cell }) => String(cell.getValue()).slice(0, 10),
+        Cell: ({ cell }) => convertToJapanTime(cell.getValue() as string),
       },
       // 編集・削除ボタンをCellに置く
       {

--- a/frontend/src/pages/curriculums.tsx
+++ b/frontend/src/pages/curriculums.tsx
@@ -15,6 +15,7 @@ import {
   UpdateCurriculumButton,
 } from '@/features/curriculum'
 import { useGetApi } from '@/hooks/useApi'
+import { convertToJapanTime } from '@/utils/convertToJapanTime'
 
 const Curriculums: NextPage = () => {
   const { data: curriculums } =
@@ -94,13 +95,13 @@ const Curriculums: NextPage = () => {
         accessorKey: 'createdAt',
         header: '作成日',
         maxSize: 0,
-        Cell: ({ cell }) => String(cell.getValue()).slice(0, 10),
+        Cell: ({ cell }) => convertToJapanTime(cell.getValue() as string),
       },
       {
         accessorKey: 'updatedAt',
         header: '最終更新日',
         maxSize: 0,
-        Cell: ({ cell }) => String(cell.getValue()).slice(0, 10),
+        Cell: ({ cell }) => convertToJapanTime(cell.getValue() as string),
       },
       // 編集・削除ボタンをCellに置く
       {

--- a/frontend/src/pages/useragents.tsx
+++ b/frontend/src/pages/useragents.tsx
@@ -16,6 +16,7 @@ import {
   useUpdateUserAgent,
 } from '@/features/userAgent'
 import { useGetApi } from '@/hooks/useApi'
+import { convertToJapanTime } from '@/utils/convertToJapanTime'
 
 const UserAgents: NextPage = () => {
   const { data: userAgents } = useGetApi<UserAgent[]>(`/useragents`)
@@ -49,13 +50,14 @@ const UserAgents: NextPage = () => {
         accessorKey: 'createdAt',
         header: '作成日',
         maxSize: 0,
-        Cell: ({ cell }) => String(cell.getValue()).slice(0, 10),
+        Cell: ({ cell }) => convertToJapanTime(cell.getValue() as string),
       },
+
       {
         accessorKey: 'updatedAt',
         header: '最終更新日',
         maxSize: 0,
-        Cell: ({ cell }) => String(cell.getValue()).slice(0, 10),
+        Cell: ({ cell }) => convertToJapanTime(cell.getValue() as string),
       },
       // 編集・削除ボタンをCellに置く
       {

--- a/frontend/src/utils/convertToJapanTime.ts
+++ b/frontend/src/utils/convertToJapanTime.ts
@@ -1,0 +1,5 @@
+// PrismaのDateは協定世界時なので、日本時間に変換する
+export const convertToJapanTime = (target: string) => {
+  const date = new Date(target)
+  return date.toLocaleDateString()
+}


### PR DESCRIPTION
## 詳細
- PrismaのDateは協定世界時なので、日本時間に変換して表示する
  - （9時間足せば日本時間になるけど、new Dateに入れたら勝手に日本時間になった）

## 動作確認

![image](https://github.com/shin-lab-sec/cyber-range-cms/assets/88410576/ec9a0b63-8ef1-4173-bc9c-34f3a4783326)
